### PR TITLE
fix a few grammatical issues in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We have been using the bot since the middle of November 2020, and we have had se
 
 ## Flow
 
-The bot is executed four times a day. The first run will write a message to to a Slack channel we have chosen to call `#mingla-med-kollegor`. It contains some generic information, like the time slots when the mingle-events happen. Currently they're hard coded to 09:15, 12:00 and 14:50.
+The bot is executed four times a day. The first run will write a message to to a Slack channel we have chosen to call `#mingla-med-kollegor`. It contains some generic information, like the time slots when the mingle-events happen. Currently its hard coded to 09:15, 12:00 and 14:50.
 
 ![](docs/screenshot-morning.png)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We have been using the bot since the middle of November 2020, and we have had se
 
 ## Flow
 
-The bot is executed four times a day. The first run will write a message to to a Slack channel we have chosen to call `#mingla-med-kollegor`. It contains some generic information, like the time slots when the mingle-events happen. Currently its hard coded to 09:15, 12:00 and 14:50.
+The bot is executed four times a day. The first run will write a message to to a Slack channel we have chosen to call `#mingla-med-kollegor`. It contains some generic information, like the time slots when the mingle-events happen. Currently it's hard coded to 09:15, 12:00 and 14:50.
 
 ![](docs/screenshot-morning.png)
 

--- a/README.md
+++ b/README.md
@@ -2,32 +2,32 @@
 
 Mingla is an Slack bot used at SVT for (semi-)spontaneous video chats. We are a group of people that misses the spontaneous chats at the coffee machine, hallways, after meetings... we got inspired by [bump-into-colleagues](https://github.com/Familjen-Sthlm/bump-into-colleagues) and articles like [this article about weak tie friendships](https://www.bbc.com/worklife/article/20200701-why-your-weak-tie-friendships-may-mean-more-than-you-think).
 
-We have been using the bot since the middle of November 2020, and we have has several fun and interesting conversations.
+We have been using the bot since the middle of November 2020, and we have had several fun and interesting conversations.
 
 ## Flow
 
-The bot is executed four times a day. The first run will write a message to to a Slack channel we have chosen to call `#mingla-med-kollegor`. It contains some generic information, like the time slots when the mingle-events will happens. Currently it's hard coded to 09:15, 12:00 and 14:50.
+The bot is executed four times a day. The first run will write a message to to a Slack channel we have chosen to call `#mingla-med-kollegor`. It contains some generic information, like the time slots when the mingle-events happen. Currently they're hard coded to 09:15, 12:00 and 14:50.
 
 ![](docs/screenshot-morning.png)
 
-> "Good morning! In 15 minutes with the first mingle event start!
-> Click at :coffee: to be part of that. Choose :sandwich: to be part
-> of the 12:00 event, and :cake: to be part of the 14:50 event."
+> "Good morning! In 15 minutes the first mingle event will start!
+> Click :coffee: to take part in it. Choose :sandwich: to take part
+> in the 12:00 event, and :cake: to take part in the 14:50 event."
 
-We also ping everybody that's currently online (active) in the channel. We uses three different reactions, `:coffee:`, `:sandwich:` and `:cake:` to select the events you like to be part of. In the screenshot I have selected the 12:00 and 09:15 events.
+We also ping everybody that's currently online (active) in the channel. We use three different reactions, `:coffee:`, `:sandwich:` and `:cake:` to select the events you'd like to take part in. In the screenshot I have selected the 12:00 and 09:15 events.
 
-It looks like it was a lazy (or maybe busy) morning and I was the only one that was interested to chat at 9. At 09:15 when the bot did it's second execution for the day, it looked at the `:coffee:` reaction and noticed that where was to few people to create rooms, so nothing will happen.
+It looks like it was a lazy (or maybe busy) morning and I was the only one that was interested to chat at 9. At 09:15 when the bot did it's second execution for the day, it looked at the `:coffee:` reaction and noticed that where was to few people to create rooms, so nothing happend.
 
-Yesterday the morning mingle was much more active. We had six people showing up (had selected "coffee"). This created two different groups.
+Yesterday the morning mingle was much more active. We had six people showing up (who had selected "coffee"). This created two different groups.
 
 ![](docs/screenshot-mingle.png)
 
 > "Here are a few nice colleagues /../ select the group that you have been
-> matched to. You are of course free to join any group if you was not selected. You have about 10 minutes to chat /.../"
+> matched to. You are of course free to join any group if you were not included. You have about 10 minutes to chat /.../"
 
-We pick a few silly names for the groups matching real places at the office. We also suggests a few topics to kickstart the conversation.
+We pick a few silly names for the groups matching real places at the office. We also suggest a few topics to kickstart the conversation.
 
-The final two (lunch and afternoon) events has the exact same flow.
+The final two (lunch and afternoon) events have the exact same flow.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Yesterday the morning mingle was much more active. We had six people showing up 
 ![](docs/screenshot-mingle.png)
 
 > "Here are a few nice colleagues /../ select the group that you have been
-> matched to. You are of course free to join any group if you were not included. You have about 10 minutes to chat /.../"
+> matched to. You are of course free to join any group if you were not selected. You have about 10 minutes to chat /.../"
 
 We pick a few silly names for the groups matching real places at the office. We also suggest a few topics to kickstart the conversation.
 


### PR DESCRIPTION
## Description

This fixes a few grammatical issues in the readme to give the project a more proffesional feel.

Heres why i chose to make the changes i made:
- Line 5 (has to had): Present to past tense.
- Line 9 (will happens to happen): in swedish you can say "kommer hända" here but in english you would drop the "will". Happens have also been changed to happen.
- Line 13 (with the first mingle event start! to the first mingle event will start!): "with" translates to "med", so that sentence would be translated to "med den första mingel eventet börja". I changed to "with" to "will" and also moved the "will" due to english sentence structure being a bit different than swedish.
- Line 14 (drop at): in swedish "at" and "on" both translates to "på", but here you would say "on" instead of "at", but it isn't needed so i decided to drop it altogether.
- Line 14-15 (be part to take part): be part= vara del i , take part in = ta del i.
- Line 17 (uses to use): "uses" is third person singular.
- Line 17: (be part to take part): be part= vara del i , take part in = ta del i.
- Line 19 (will happen to happend): since "looked" is past tense you also have to keep that up in the rest of the sentence
- Line 21 (include "who"): its sounds a bit odd without the "who"
- Line 26 (was to were): its always were if "you" comes before.
- Line 28 (suggests to suggest): With verbs, only those with a third-person singular noun or pronoun as a subject add an s to the end.
- Line 30 (has to have): since there are 2 more events, you would use have since thats for plural.
## Checklist:

- [✅ ] I confirm that I wrote and/or have the right to submit the contents of my PR, by agreeing to the Developer Certificate of Origin (see https://github.com/svt/open-source-project-template/blob/master/docs/CONTRIBUTING.adoc[docs/CONTRIBUTING]).
- [✅] PR has an informative and human-readable title
- [✅] Changes are limited to a single goal (no scope creep)
- [✅] Code can be automatically merged (no conflicts)

